### PR TITLE
fix(stream): Don't decode strings

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -7,7 +7,10 @@ function getStream(stream: NodeJS.ReadableStream): Promise<string> {
     // TODO[engines.node@>=18]: Use `reduce`
     return new Promise((resolve, reject) => {
         let data = "";
-        stream.on("data", (chunk) => (data += chunk));
+        stream.on("data", (chunk) => {
+            expect(typeof chunk).toBe("string");
+            data += chunk;
+        });
         stream.on("end", () => resolve(data));
         stream.on("error", reject);
         stream.resume();

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export class DecodeStream extends Transform {
     private readBytes = 0;
 
     constructor(options?: SnifferOptions) {
-        super();
+        super({ decodeStrings: false, encoding: "utf-8" });
         this.sniffer = new Sniffer(options);
         this.maxBytes = options?.maxBytes ?? 1024;
     }
@@ -63,7 +63,7 @@ export class DecodeStream extends Transform {
         }
 
         const iconv = decodeStream(this.sniffer.encoding);
-        iconv.on("data", (chunk: string) => this.push(chunk));
+        iconv.on("data", (chunk: string) => this.push(chunk, "utf-8"));
         iconv.on("end", () => this.push(null));
 
         this.iconv = iconv;


### PR DESCRIPTION
Before, we would output binary data at the other end of the stream.