### PR TITLE
fix(sniffer): Handle names/labels with underscores (e.g. Shift_JIS)

### DIFF
--- a/src/charset-with-underscore.spec.ts
+++ b/src/charset-with-underscore.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { Sniffer, ResultType } from "./sniffer.js";
+
+const XML_ENCODING = "<?xml encoding='Shift_JIS'>";
+const META_CONTENT =
+    "<meta http-equiv='content-type' content=charset=Shift_JIS>";
+
+const META_CHARSET = "<meta charset=Shift_JIS>";
+
+describe("Sniffer", () => {
+    it("should recognize XML ", () => {
+        const sniffer = new Sniffer();
+        sniffer.write(Buffer.from(XML_ENCODING));
+        expect(sniffer.encoding).toBe("Shift_JIS");
+        expect(sniffer.resultType).toBe(ResultType.XML_ENCODING);
+    });
+
+    it("should recognize HTML meta tag charset, lower", () => {
+        const sniffer = new Sniffer();
+        sniffer.write(Buffer.from(META_CHARSET));
+        expect(sniffer.encoding).toBe("Shift_JIS");
+        expect(sniffer.resultType).toBe(ResultType.META_TAG);
+    });
+
+    it("should recognize HTML meta tag charset, upper", () => {
+        const sniffer = new Sniffer();
+        sniffer.write(Buffer.from(META_CHARSET.toUpperCase()));
+        expect(sniffer.encoding).toBe("Shift_JIS");
+        expect(sniffer.resultType).toBe(ResultType.META_TAG);
+    });
+
+    it("should recognize HTML meta tag charset, quoted", () => {
+        const sniffer = new Sniffer();
+        sniffer.write(Buffer.from("<Meta Charset  =  ' Shift_JIS '>"));
+        expect(sniffer.encoding).toBe("Shift_JIS");
+        expect(sniffer.resultType).toBe(ResultType.META_TAG);
+    });
+
+    it("should recognize HTML meta tag http-equiv, lower", () => {
+        const sniffer = new Sniffer();
+        sniffer.write(Buffer.from(META_CONTENT));
+        expect(sniffer.encoding).toBe("Shift_JIS");
+        expect(sniffer.resultType).toBe(ResultType.META_TAG);
+    });
+
+    it("should recognize HTML meta tag http-equiv, upper", () => {
+        const sniffer = new Sniffer();
+        sniffer.write(Buffer.from(META_CONTENT.toUpperCase()));
+        expect(sniffer.encoding).toBe("Shift_JIS");
+        expect(sniffer.resultType).toBe(ResultType.META_TAG);
+    });
+
+    it("should recognize HTML meta tag http-equiv, byte-by-byte", () => {
+        const sniffer = new Sniffer();
+        for (const c of META_CONTENT) sniffer.write(Buffer.from(c));
+        expect(sniffer.encoding).toBe("Shift_JIS");
+        expect(sniffer.resultType).toBe(ResultType.META_TAG);
+    });
+});

--- a/src/sniffer.ts
+++ b/src/sniffer.ts
@@ -701,7 +701,7 @@ export class Sniffer {
             this.handleAttributeValue();
             this.state = State.BeforeTag;
         } else if (this.attribType === AttribType.Charset) {
-            this.attributeValue.push(c | 0x20);
+            this.attributeValue.push(c | (c >= 0x41 && c <= 0x5a ? 0x20 : 0));
         }
     }
 
@@ -750,7 +750,7 @@ export class Sniffer {
             this.handleMetaContentValue();
             this.state = State.AttributeValueUnquoted;
         } else {
-            this.attributeValue.push(c | 0x20);
+            this.attributeValue.push(c | (c >= 0x41 && c <= 0x5a ? 0x20 : 0));
         }
     }
 
@@ -760,7 +760,7 @@ export class Sniffer {
             this.state = State.AttributeValueUnquoted;
             this.stateAttributeValueUnquoted(c);
         } else {
-            this.attributeValue.push(c | 0x20);
+            this.attributeValue.push(c | (c >= 0x41 && c <= 0x5a ? 0x20 : 0));
         }
     }
 
@@ -771,7 +771,7 @@ export class Sniffer {
             this.state = State.AttributeValueQuoted;
             this.stateAttributeValueQuoted(c);
         } else {
-            this.attributeValue.push(c | 0x20);
+            this.attributeValue.push(c | (c >= 0x41 && c <= 0x5a ? 0x20 : 0));
         }
     }
 
@@ -787,7 +787,7 @@ export class Sniffer {
             this.state = State.AttributeValueQuoted;
             this.stateAttributeValueQuoted(c);
         } else {
-            this.attributeValue.push(c | 0x20);
+            this.attributeValue.push(c | (c >= 0x41 && c <= 0x5a ? 0x20 : 0));
         }
     }
 
@@ -825,7 +825,7 @@ export class Sniffer {
             this.handleAttributeValue();
             this.state = State.BeforeAttribute;
         } else if (this.attribType === AttribType.Charset) {
-            this.attributeValue.push(c | 0x20);
+            this.attributeValue.push(c | (c >= 0x41 && c <= 0x5a ? 0x20 : 0));
         }
     }
 
@@ -885,7 +885,7 @@ export class Sniffer {
         } else if (c <= Chars.SPACE) {
             this.state = State.WeirdTag;
         } else {
-            this.attributeValue.push(c | 0x20);
+            this.attributeValue.push(c | (c >= 0x41 && c <= 0x5a ? 0x20 : 0));
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/fb55/encoding-sniffer/issues/927.

`this.attributeValue.push(c | 0x20)`, when `c` is a 0x5f `_` underscore character (01011111) results in a 0x7f (01111111) DEL character getting pushed onto the `attributeValue` array. So `Shift_JIS` becomes `shift␡jis`.

So we need to not do the `c | 0x20` conversion if `c` is an underscore.